### PR TITLE
do not fail on devices without entPhysicalMfgName

### DIFF
--- a/qnap/checks/qnap_fans
+++ b/qnap/checks/qnap_fans
@@ -65,4 +65,4 @@ check_info['qnap_fans'] = (check_qnap_fans, "QNAP %s", 1, inventory_qnap_fans)
 
 snmp_info['qnap_fans'] = ( ".1.3.6.1.4.1.24681.1.2.15.1.3", [ "1", "2" ] )
 snmp_scan_functions['qnap_fans'] = \
-    lambda oid: "QNAP Systems" in oid('.1.3.6.1.2.1.47.1.1.1.1.12.1')
+    lambda oid: oid('.1.3.6.1.2.1.47.1.1.1.1.12.1') and "QNAP Systems" in oid('.1.3.6.1.2.1.47.1.1.1.1.12.1')

--- a/qnap/checks/qnap_hdd
+++ b/qnap/checks/qnap_hdd
@@ -60,4 +60,4 @@ check_info['qnap_hdd'] = (check_qnap_hdd, "QNAP %s", 1, inventory_qnap_hdd)
 
 snmp_info['qnap_hdd'] = ( ".1.3.6.1.4.1.24681.1.2", [ "11.1.2", "11.1.7" , "11.1.3", "11.1.5"] )
 snmp_scan_functions['qnap_hdd'] = \
-    lambda oid: "QNAP Systems" in oid('.1.3.6.1.2.1.47.1.1.1.1.12.1')
+    lambda oid: oid('.1.3.6.1.2.1.47.1.1.1.1.12.1') and "QNAP Systems" in oid('.1.3.6.1.2.1.47.1.1.1.1.12.1')

--- a/qnap/checks/qnap_info
+++ b/qnap/checks/qnap_info
@@ -44,4 +44,4 @@ check_info['qnap_info'] = (check_qnap_info, "QNAP Info", 0, inventory_qnap_info)
 
 snmp_info['qnap_info'] = ( ".1.3.6.1", [ "2.1.1.1.0", "2.1.47.1.1.1.1.11.1", "2.1.25.1.1.0" ] )
 snmp_scan_functions['qnap_info'] = \
-    lambda oid: "QNAP Systems" in oid('.1.3.6.1.2.1.47.1.1.1.1.12.1')
+    lambda oid: oid('.1.3.6.1.2.1.47.1.1.1.1.12.1') and "QNAP Systems" in oid('.1.3.6.1.2.1.47.1.1.1.1.12.1')

--- a/qnap/checks/qnap_temp
+++ b/qnap/checks/qnap_temp
@@ -68,4 +68,4 @@ check_info['qnap_temp'] = (check_qnap_temp, "QNAP %s", 1, inventory_qnap_temp)
 
 snmp_info['qnap_temp'] = ( ".1.3.6.1.4.1.24681.1.2", ["5", "6"] )
 snmp_scan_functions['qnap_temp'] = \
-    lambda oid: "QNAP Systems" in oid('.1.3.6.1.2.1.47.1.1.1.1.12.1')
+    lambda oid: oid('.1.3.6.1.2.1.47.1.1.1.1.12.1') and "QNAP Systems" in oid('.1.3.6.1.2.1.47.1.1.1.1.12.1')


### PR DESCRIPTION
The scan function failed on devices without entPhysicalMfgName because oid() would return None.

This patch should fix that.

Please keep in mind that the SNMP scan function runs on all SNMP enabled devices to detect if the SNMP check would work.