### PR TITLE
qemu-agent: if last line is empty; del and check previous line

### DIFF
--- a/qemu_kvm/agent/plugins/qemu
+++ b/qemu_kvm/agent/plugins/qemu
@@ -23,6 +23,9 @@ if which virsh >/dev/null; then
 		if [ $PID -gt 0 ]; then
 			#DATA=$(top -p $PID -n 1 -b | tail -n 2 | head -n 1 | awk -- '{print $9" "$10}')
 			DATA=$(top -p $PID -n 1 -b | tail -1  | awk -- '{print $9" "$10}')
+			if [ -n "$DATA" ]; then
+                        	DATA=$(top -p $PID -n 1 -b | sed '$ d' | tail -1  | awk -- '{print $9" "$10}')
+                    	fi
 		else
 			DATA=""
 		fi


### PR DESCRIPTION
It can happen that in the output of top the last line is empty and the relevant output is in the line before; in that case delete the line and get the data then